### PR TITLE
Fix Tic Tac Toe example not loading even with the correct path

### DIFF
--- a/specification/components.md
+++ b/specification/components.md
@@ -97,7 +97,7 @@ Note also how the `coordinate` schema is used twice (in the `rowParam` and `colu
 
 ## Tic Tac Toe Example
 
-The complete [Tic Tac Toe sample API](/examples/tictactoe.yaml) (not included here for brevity) makes heavy use of components. Note for example how different endpoints return a `#/components/schemas/status` on success, or a `#/components/schemas/errorMessage` on error.
+The complete [Tic Tac Toe sample API](https://github.com/OAI/Documentation/blob/main/examples/tictactoe.yaml) (not included here for brevity) makes heavy use of components. Note for example how different endpoints return a `#/components/schemas/status` on success, or a `#/components/schemas/errorMessage` on error.
 
 ## Summary
 

--- a/specification/content.md
+++ b/specification/content.md
@@ -107,7 +107,7 @@ content:
 
 ## Tic Tac Toe Example
 
-The [Tic Tac Toe sample API](/examples/tictactoe.yaml) given so far has one endpoint with one unspecified response. The snippet below adds the description of this content:
+The [Tic Tac Toe sample API](https://github.com/OAI/Documentation/blob/main/examples/tictactoe.yaml) given so far has one endpoint with one unspecified response. The snippet below adds the description of this content:
 
 ```yaml
 openapi: 3.1.0

--- a/specification/content.md
+++ b/specification/content.md
@@ -107,7 +107,7 @@ content:
 
 ## Tic Tac Toe Example
 
-The [Tic Tac Toe sample API](examples/tictactoe.yaml) given so far has one endpoint with one unspecified response. The snippet below adds the description of this content:
+The [Tic Tac Toe sample API](/examples/tictactoe.yaml) given so far has one endpoint with one unspecified response. The snippet below adds the description of this content:
 
 ```yaml
 openapi: 3.1.0

--- a/specification/docs.md
+++ b/specification/docs.md
@@ -166,7 +166,7 @@ schema:
 
 On the other hand, the `examples` field (found in [Parameter](https://spec.openapis.org/oas/v3.1.0#parameterExample) and [Media Type](https://spec.openapis.org/oas/v3.1.0#mediaTypeExample) Objects) is a map pairing an example name with an [Example Object](https://spec.openapis.org/oas/v3.1.0#example-object). This object provides a `summary` and a `description` for the example along with the actual code (inside the `value` field or as an external reference in the `externalValue` field, but not both).
 
-This is a snippet from the [Tic Tac Toe sample API](/examples/tictactoe.yaml):
+This is a snippet from the [Tic Tac Toe sample API](https://github.com/OAI/Documentation/blob/main/examples/tictactoe.yaml):
 
 ```yaml
 responses:

--- a/specification/parameters.md
+++ b/specification/parameters.md
@@ -157,7 +157,7 @@ The Request Body Object also has a `description` string and a `required` boolean
 
 ## Tic Tac Toe Example
 
-The [Tic Tac Toe sample API](examples/tictactoe.yaml) contains two endpoints, one without parameters or request body (`/board`) and another one with both (`/board/{row}/{column}`). The relevant code snippet for the second endpoint is shown below and it should be easy to understand after reading this page.
+The [Tic Tac Toe sample API](/examples/tictactoe.yaml) contains two endpoints, one without parameters or request body (`/board`) and another one with both (`/board/{row}/{column}`). The relevant code snippet for the second endpoint is shown below and it should be easy to understand after reading this page.
 
 ```yaml
 paths:

--- a/specification/parameters.md
+++ b/specification/parameters.md
@@ -157,7 +157,7 @@ The Request Body Object also has a `description` string and a `required` boolean
 
 ## Tic Tac Toe Example
 
-The [Tic Tac Toe sample API](/examples/tictactoe.yaml) contains two endpoints, one without parameters or request body (`/board`) and another one with both (`/board/{row}/{column}`). The relevant code snippet for the second endpoint is shown below and it should be easy to understand after reading this page.
+The [Tic Tac Toe sample API](https://github.com/OAI/Documentation/blob/main/examples/tictactoe.yaml) contains two endpoints, one without parameters or request body (`/board`) and another one with both (`/board/{row}/{column}`). The relevant code snippet for the second endpoint is shown below and it should be easy to understand after reading this page.
 
 ```yaml
 paths:

--- a/specification/paths.md
+++ b/specification/paths.md
@@ -127,7 +127,7 @@ paths:
             ...
 ```
 
-The complete document can be found in the [Tic Tac Toe sample API](/examples/tictactoe.yaml).
+The complete document can be found in the [Tic Tac Toe sample API](https://github.com/OAI/Documentation/blob/main/examples/tictactoe.yaml).
 
 ## Summary
 

--- a/specification/paths.md
+++ b/specification/paths.md
@@ -22,7 +22,7 @@ Every field in the [Paths Object](https://spec.openapis.org/oas/v3.1.0#paths-obj
 
 Paths **must start with a forward slash** `/` since they are directly appended to the server URL (described in the [API Servers](servers) page) to construct the full endpoint URL.
 
-The [Tic Tac Toe sample API](examples/tictactoe.yaml) is used in this guide to exemplify each concept and it is built piece by piece as the guide progresses. Here's the first snippet already containing a single endpoint:
+The [Tic Tac Toe sample API](/examples/tictactoe.yaml) is used in this guide to exemplify each concept and it is built piece by piece as the guide progresses. Here's the first snippet already containing a single endpoint:
 
 ```yaml
 openapi: 3.1.0
@@ -127,7 +127,7 @@ paths:
             ...
 ```
 
-The complete document can be found in the [Tic Tac Toe sample API](examples/tictactoe.yaml).
+The complete document can be found in the [Tic Tac Toe sample API](/examples/tictactoe.yaml).
 
 ## Summary
 


### PR DESCRIPTION
I noticed that even after the path fix the page still can't be opened because it is not a "GitHub Pages" site.
By using an URL that directs directly to the Tic Tac Toe example file in GitHub we should fix the problem.

I believe this would be the best solution to have it working. Thank you for the documentation!