### PR TITLE
Fixing syntax of security in TicTacToe OpenAPI example

### DIFF
--- a/examples/tictactoe.yaml
+++ b/examples/tictactoe.yaml
@@ -24,9 +24,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/status"
       security:
-        - bearerHttpAuthentication: []
-        - user2AppOauth:
-          - board:write
+        - apiKey: []
+        - app2AppOauth:
+          - board:read
 
   # Single square operations
   /board/{row}/{column}:
@@ -56,7 +56,7 @@ paths:
       security:
         - bearerHttpAuthentication: []
         - user2AppOauth:
-          - board:write
+          - board:read
     put:
       summary: Set a single board square
       description: Places a mark on the board and retrieves the whole board and the winner (if any).

--- a/examples/tictactoe.yaml
+++ b/examples/tictactoe.yaml
@@ -24,9 +24,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/status"
       security:
-        apiKey: []
-        app2AppOauth:
-        - board:read
+        - bearerHttpAuthentication: []
+        - user2AppOauth:
+          - board:write
 
   # Single square operations
   /board/{row}/{column}:
@@ -54,9 +54,9 @@ paths:
                 $ref: "#/components/schemas/errorMessage"
               example: "Illegal coordinates"
       security:
-        bearerHttpAuthentication: []
-        user2AppOauth:
-        - board:read
+        - bearerHttpAuthentication: []
+        - user2AppOauth:
+          - board:write
     put:
       summary: Set a single board square
       description: Places a mark on the board and retrieves the whole board and the winner (if any).
@@ -90,9 +90,9 @@ paths:
                 invalidMark:
                   value: "Invalid Mark (X or O)."
       security:
-        bearerHttpAuthentication: []
-        user2AppOauth:
-        - board:write
+        - bearerHttpAuthentication: []
+        - user2AppOauth:
+          - board:write
 
 components:
   parameters:


### PR DESCRIPTION
The provided tictactoe.yaml OpenAPI example is not valid and fails to be rendered in Redocly.

Security element's type is an array. I have fixed the syntax in security of the operations. 
