### PR TITLE
Advertise Markdown files as "source code" of the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.dot diff
+*.md linguist-detectable


### PR DESCRIPTION
Correctly identifying main language of the repo on GitHub may help attracting more contributors.

|Before|After|
|---|---|
|![image](https://github.com/OAI/learn.openapis.org/assets/25753618/13bfc6f4-0f25-4cc4-a536-cf55b967cc12)|![image](https://github.com/OAI/learn.openapis.org/assets/25753618/6c60de6b-9be5-4d60-a8d7-ceb5bdf2ece2)|
|![image](https://github.com/OAI/learn.openapis.org/assets/25753618/99fd7908-c9bd-47c6-8607-72a4ad339b23)|![image](https://github.com/OAI/learn.openapis.org/assets/25753618/29a1a8ac-c67a-4b48-a9ce-64522721c852)|