### PR TITLE
Update convert-examples-to-json.yaml

### DIFF
--- a/.github/workflows/convert-examples-to-json.yaml
+++ b/.github/workflows/convert-examples-to-json.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2 # checkout repo content
+    - uses: actions/checkout@v4 # checkout repo content
 
     - uses: actions/setup-node@v4 # setup Node.js
       with:


### PR DESCRIPTION
Use current version of checkout action to avoid [warning on deprecated node12](https://github.com/OAI/learn.openapis.org/actions/runs/10494505910)