### PR TITLE
examples/v3.1/tictactoe fix security property name

### DIFF
--- a/examples/v3.1/tictactoe.json
+++ b/examples/v3.1/tictactoe.json
@@ -31,7 +31,7 @@
         },
         "security": [
           {
-            "apiKey": []
+            "defaultApiKey": []
           },
           {
             "app2AppOauth": ["board:read"]

--- a/examples/v3.1/tictactoe.yaml
+++ b/examples/v3.1/tictactoe.yaml
@@ -24,7 +24,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/status'
       security:
-        - apiKey: []
+        - defaultApiKey: []
         - app2AppOauth:
             - board:read
   # Single square operations


### PR DESCRIPTION
Unless I'm misunderstanding it, this corrects the property name inside this security object to correctly correspond to a key of /components/securitySchemas, which it did not previously.