### PR TITLE
The servers page was missing a link to the next page (security)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM bretfisher/jekyll-serve
 WORKDIR /site
 
 # install dependencies
-COPY Gemfile Gemfile.lock . 
+COPY Gemfile Gemfile.lock ./ 
 RUN bundle install
 
 # install the site

--- a/specification/servers.md
+++ b/specification/servers.md
@@ -112,3 +112,5 @@ This page has shown that:
 - Server lists can be provided through the `servers` array.
 - This array is present at different levels ([OpenAPI Object](https://spec.openapis.org/oas/v3.1.0#oasServers), [Path Item Object](https://spec.openapis.org/oas/v3.1.0#pathItemServers) and  [Operation Object](https://spec.openapis.org/oas/v3.1.0#operationServers)) and only the innermost one is used.
 - Server URLs can contain `variables` for further customization like `https://{username}.server.com:{port}/{version}`
+
+The [next page](security) shows how to describe API security.


### PR DESCRIPTION
changes:
- minor modification in the Dockerfile to avoid a build warning
- added a link to the following page in specification/servers 