### PR TITLE
Fix typo in content.md

### DIFF
--- a/specification/content.md
+++ b/specification/content.md
@@ -153,7 +153,7 @@ paths:
   ...
 ```
 
-The response contains an object is JSON format with two fields:
+The response contains an object in JSON format with two fields:
 
 - `winner` is a string with only three possible values: `.`, `X` and `O`.
 - `board` is a 3-element array where each item is another 3-element array, effectively building a 3x3 square matrix. Each element in the matrix is a string with only three possible values: `.`, `X` and `O`.


### PR DESCRIPTION
Fix typo in "Content of Message bodies" page change "is" to "in"