### PR TITLE
Add a community page to the documentation

### DIFF
--- a/community.md
+++ b/community.md
@@ -1,0 +1,90 @@
+---
+layout: default
+title: Community
+nav_order: 20
+---
+
+# OpenAPI Community
+
+The OpenAPI Initiative is an open group, and we welcome participation in all our activities.
+Use this page to find out where you can find resources and how to get more involved with the project.
+
+## Quick Reference
+
+- Main website: <https://www.openapis.org>
+- Specification: <https://spec.openapis.org>
+- Documentation: <https://learn.openapis.org> (this website)
+- GitHub organisation: <https://github.com/OAI/>
+
+## Connect With OpenAPI
+
+Find and follow/chat with us in one of these places:
+
+- [Newsletter](https://www.openapis.org) (scroll down for the signup form) - A low-traffic summary of news from the group.
+- [GitHub](https://github.com/OAI) is our organization, you can find all our projects listed there. Use discussions for questions, and feel free to check the issue and pull request lists to see what's in progress.
+- [LinkedIn](https://www.linkedin.com/company/open-api-initiative/) is another good way to get updates on our news.
+- [Slack](https://communityinviter.com/apps/open-api/openapi) for informal chat between project members.
+
+## Membership
+
+Being a member of OpenAPI Initiative gives your organization a voice within the project, as well as supporting our activities.
+
+- [View the list of members](https://www.openapis.org/membership/members)
+- [Learn more about membership](https://www.openapis.org/membership/join)
+
+## Participate in Working Groups
+
+OpenAPI Initiative publishes more than one specification, each with its own repository and community.
+
+### OpenAPI Specification
+
+The main OpenAPI Specification project provides a human- and machine-readable format for describing HTTP APIs.
+
+- **Published resources:** [Specification](https://spec.openapis.org/#openapi-specification)
+  | [Documentation](https://learn.openapis.org/)
+  | [JSON Schema](https://spec.openapis.org/#openapi-specification-schemas)
+  | [Registries](https://spec.openapis.org/registry/index.html)
+
+- **On GitHub:** [ReadMe](https://github.com/OAI/OpenAPI-Specification/?tab=readme-ov-file#readme)
+  | [Discuss OpenAPI (questions welcome)](https://github.com/OAI/OpenAPI-Specification/discussions)
+  | [Read release notes](https://github.com/OAI/OpenAPI-Specification/releases)
+  | [Review active pull requests](https://github.com/OAI/OpenAPI-Specification/pulls)
+  | [Issues list](https://github.com/OAI/OpenAPI-Specification/issues)
+
+- **Weekly Technical Meetings:** [Meetings list](https://github.com/OAI/OpenAPI-Specification/issues?q=is%3Aissue%20state%3Aopen%20%22Open%20Community%22) - The joining instructions are in the agenda for the meeting.
+
+- **On Slack:** `#spec` channel
+
+### Arazzo Specification
+
+Arazzo Specification describes a sequence of API calls and how data flows between multiple endpoints.
+
+- **Published resources:** [Specification](https://spec.openapis.org/#arazzo-specification)
+  | [JSON Schema](https://spec.openapis.org/#arazzo-schemas)
+
+- **On GitHub:** [ReadMe](https://github.com/OAI/Arazzo-Specification/?tab=readme-ov-file#readme)
+  | [Discuss OpenAPI (questions welcome)](https://github.com/OAI/Arazzo-Specification/discussions)
+  | [Read release notes](https://github.com/OAI/Arazzo-Specification/releases)
+  | [Review active pull requests](https://github.com/OAI/Arazzo-Specification/pulls)
+  | [Issues list](https://github.com/OAI/Arazzo-Specification/issues)
+
+- **Technical Meetings:** [Meetings list](https://github.com/OAI/Arazzo-Specification/issues?q=is%3Aissue%20state%3Aopen%20%22Meeting%22) - The joining instructions are in the agenda for the meeting.
+
+- **On Slack:** `#arazzo` channel
+
+### Overlay Specification
+
+- **Published resources:** [Specification](https://spec.openapis.org/#overlay-specification)
+  | [Documentation](https://learn.openapis.org/overlay/)
+  | [JSON Schema](https://spec.openapis.org/#overlay-specification-schemas)
+
+- **On GitHub:** [ReadMe](https://github.com/OAI/Overlay-Specification/?tab=readme-ov-file#readme)
+  | [Discuss OpenAPI (questions welcome)](https://github.com/OAI/Overlay-Specification/discussions)
+  | [Read release notes](https://github.com/OAI/Overlay-Specification/releases)
+  | [Review active pull requests](https://github.com/OAI/Overlay-Specification/pulls)
+  | [Issues list](https://github.com/OAI/Overlay-Specification/issues)
+
+- **Technical Meetings:** [Meetings list](https://github.com/OAI/Overlay-Specification/discussions/categories/meeting-notes) - The joining instructions are in the agenda for the meeting.
+
+- **On Slack:** `#overlays` channel
+


### PR DESCRIPTION
When reviewing the Overlays documentation with the group this week, we realised that there's a disconnect between the information (outdated!) on the community site, and the place that we think most people would visit to find information (the documentation). This pull request brings over some of the information from the community repository readme, updates it, and makes it into a documentation page.